### PR TITLE
Update artifactIds and versions for servlet-api and jsp-api

### DIFF
--- a/01-springvsboot/simple-spring-webapp/pom.xml
+++ b/01-springvsboot/simple-spring-webapp/pom.xml
@@ -14,9 +14,9 @@
 		<java.version>1.8</java.version>
 
 		<!-- Web -->
-		<jsp.version>2.2</jsp.version>
+		<jsp.version>2.3.1</jsp.version>
 		<jstl.version>1.2</jstl.version>
-		<servlet.version>2.5</servlet.version>
+		<servlet.version>3.1.0</servlet.version>
 
 		<!-- Spring -->
 		<spring-framework.version>4.3.2.RELEASE</spring-framework.version>
@@ -40,13 +40,13 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 			<version>${servlet.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet.jsp</groupId>
-			<artifactId>jsp-api</artifactId>
+			<artifactId>javax.servlet.jsp-api</artifactId>
 			<version>${jsp.version}</version>
 			<scope>provided</scope>
 		</dependency>


### PR DESCRIPTION
There are new artifactIds for both servlet-api and jsp-api available in Maven:

servlet-api: (old artifact) https://mvnrepository.com/artifact/javax.servlet/servlet-api -> (new artifact) https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api

jsp-api: (old artifact) https://mvnrepository.com/artifact/javax.servlet.jsp/jsp-api -> (new artifact) https://mvnrepository.com/artifact/javax.servlet.jsp/javax.servlet.jsp-api